### PR TITLE
Switch Dependabot to checking weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,12 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: npm
     directory: "/javascript"
     schedule:
-      interval: daily
+      interval: "weekly"
   - package-ecosystem: bundler
     directory: "/ruby"
     schedule:
-      interval: weekly
+      interval: "weekly"


### PR DESCRIPTION
We now use "weekly" throughout our docs and examples, as most users seem to prefer slightly less package churn than daily.