### PR TITLE
Update Bundler version in Gemfile.lock to 2.7.2

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,13 +1,23 @@
 name: Greetings
 
-on: [pull_request, issues]
+on:
+  pull_request:
+    types:
+      - opened
+  issues:
+    types:
+      - opened
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   greeting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/first-interaction@v1
+    - uses: actions/first-interaction@v3
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        issue-message: 'Message that will be displayed on users'' first issue'
-        pr-message: 'Message that will be displayed on users'' first pr'
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        issue_message: 'Message that will be displayed on users'' first issue'
+        pr_message: 'Message that will be displayed on users'' first pr'

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -12,4 +12,4 @@ DEPENDENCIES
   uk_phone_numbers (~> 0.1.0)
 
 BUNDLED WITH
-   1.17.3
+   2.7.2


### PR DESCRIPTION
The version of Bundler used in this repo is no longer supported.

This pull request updates Bundler to version 2.7.2.

We used the command `bundle update --bundler` in the `./ruby` folder.

## Additional Changes

This PR also includes a fix for the GitHub Actions workflow that was failing:

- **Fixed GitHub Actions Greetings Workflow**: Updated `actions/first-interaction` from v1 to v3, added required permissions for issues and pull-requests, and corrected parameter names to resolve workflow failures.

<img width="940" height="316" alt="image" src="https://github.com/user-attachments/assets/3f0c8081-6b34-427c-8592-08768cdea51d" />